### PR TITLE
Bugfix/import path in windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ var path = require('path')
 var eol = require('os').EOL
 var fs = require('fs-extra')
 var chalk = require('chalk')
+var os = require('os')
 
 var log = require('./log')
 
@@ -64,11 +65,22 @@ function outputTips() {
     var ts = tips[key]
     console.log(logYellow('     name\t\tpath'))
     ts.forEach(function (tip) {
-      var p = tip.path
-      p.indexOf('../') === -1 && p.indexOf('./') === -1 && (p = './' + p)
-      console.log(logGreen('     ' + tip.name), '  (' + p + ')')
+      console.log(logGreen('     ' + tip.name), '  (' + tip.path + ')')
     })
   }
+}
+
+// originPath [String] relative path
+// 1. replace \ to / in Windows
+// 2. insert './' at head if needed
+function convertPathForImport(originPath) {
+  if (os.platform() === 'win32') {
+    var result = originPath.replace('\\', '/')    
+  }
+  if (result.indexOf('../') === -1 && result.indexOf('./') === -1) {
+    result = './' + result
+  }
+  return result
 }
 
 function initPacker (options) {
@@ -104,12 +116,12 @@ function processComponents (options) {
     var name = comp[0].toUpperCase() + comp.substr(1)
     var thePath = path.resolve(cmpPath, comp)
     var p = path.relative(path.parse(packerPath).dir, path.resolve(cmpPath, comp))
-    p.indexOf('../') === -1 && p.indexOf('./') === -1 && (p = './' + p)
+    p = convertPathForImport(p)
     content += 'import ' + name + ' from \'' + p + '\'' + eol
     exportLine += name + ', '
     tips.components.push({
       name: comp,
-      path: path.relative(root, thePath)
+      path: thePath
     })
   })
 }
@@ -135,12 +147,12 @@ function processApis (options) {
     var name = api[0].toUpperCase() + api.substr(1)
     var thePath = path.resolve(apisPath, api)
     var p = path.relative(path.parse(packerPath).dir, thePath)
-    p.indexOf('../') === -1 && p.indexOf('./') === -1 && (p = './' + p)
+    p = convertPathForImport(p)
     content += 'import ' + name + ' from \'' + p + '\'' + eol
     exportLine += name + ', '
     tips.apis.push({
       name: api,
-      path: path.relative(root, thePath)
+      path: thePath
     })
   })
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ function outputTips() {
 // 2. insert './' at head if needed
 function convertPathForImport(originPath) {
   if (os.platform() === 'win32') {
-    var result = originPath.replace('\\', '/')    
+    var result = originPath.replace(/\\/g, '/')    
   }
   if (result.indexOf('../') === -1 && result.indexOf('./') === -1) {
     result = './' + result
@@ -121,7 +121,7 @@ function processComponents (options) {
     exportLine += name + ', '
     tips.components.push({
       name: comp,
-      path: thePath
+      path: convertPathForImport(path.relative(root, thePath))
     })
   })
 }
@@ -152,7 +152,7 @@ function processApis (options) {
     exportLine += name + ', '
     tips.apis.push({
       name: api,
-      path: thePath
+      path: convertPathForImport(path.relative(root, thePath))
     })
   })
 }
@@ -177,13 +177,12 @@ function processLoaders (options) {
   loaders.forEach(function (loader) {
     var name = loader[0].toUpperCase() + loader.substr(1)
     var thePath = path.resolve(loadersPath, loader)
-    var p = path.relative(path.parse(packerPath).dir, thePath)
-    p.indexOf('../') === -1 && p.indexOf('./') === -1 && (p = './' + p)
+    var p = convertPathForImport(path.relative(path.parse(packerPath).dir, thePath))
     content += 'import ' + name + ' from \'' + p + '\'' + eol
     exportLine += name + ', '
     tips.loaders.push({
       name: loader,
-      path: path.relative(root, thePath)
+      path: convertPathForImport(path.relative(root, thePath))
     })
   })
 }


### PR DESCRIPTION
Move from https://github.com/MrRaindrop/wwp/pull/1.

@Jinjiang

I think this problem isn't about path but import path. It's just `./` `../` whatever the platform is. `path.sep` seems dosen't help. `path.posix.relative` give a wrong result in Windows and `path.relative` in win32 always give a result contains `/`.

So, what we need do is convert Windows path for import, it's there better a way to do this?
